### PR TITLE
Add entity_category to miwifi

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,12 @@ Many more Xiaomi and Redmi routers supported by MiWiFi (OpenWRT - Luci API)
 
 | Image                                               | Router                                                           | Firmware version                                     | Status                        |
 | --------------------------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------- | ----------------------------- |
-| ![](http://www1.miwifi.com/statics/img/RA70.png)    | [Xiaomi AX9000](https://www.mi.com/mirouter/ax9000)               | <ul><li>1.0.108(CN)</li><li>3.0.40(Global)</li></ul> | Supported                     |
-| ![](http://www1.miwifi.com/statics/img/RA72.png)    | [Xiaomi AX3600](https://www.mi.com/r3600)                         | <ul><li>1.0.79(CN)</li><li>3.0.22(Global)</li></ul>  | Supported                     |
-| ![](http://www1.miwifi.com/statics/img/AX1800.png)  | [Xiaomi AX1800](https://www.mi.com/buy/detail?product_id=12027)   | <ul><li>1.0.378(CN)</li></ul>                        | Supported                     |
-| ![](http://miwifi.com/statics/img/RA67.png)         | [Redmi AX5](https://www.mi.com/buy/detail?product_id=12258)       | <ul><li>1.0.33(CN)</li><li>3.0.34(Global)</li></ul>  | Supported                     |
-| ![](http://www1.miwifi.com/statics/img/2100@1x.png) | [Xiaomi AC2100](https://www.mi.com/miwifiac)                       | <ul><li>2.0.23(CN)</li><li>2.0.743(CN)</li></ul>     | Supported                     |
-| ![](http://www1.miwifi.com/statics/img/R4AC.png)    | [Xiaomi Mi Wifi 4A](https://www.mi.com/miwifi4a/)                   | <ul><li>2.28.58(CN)</li></ul>                        | Supported                     |
-| ![](http://www1.miwifi.com/statics/img/r3p.png)     | [Xiaomi PRO R3P](http://item.mi.com/1172800043.html)              | <ul><li>2.16.29(CN)</li></ul>                        | With restrictions<sup>*</sup> |
+| ![](http://www1.miwifi.com/statics/img/RA70.png)    | [Xiaomi AX9000](https://www.mi.com/mirouter/ax9000)              | <ul><li>1.0.108(CN)</li><li>3.0.40(Global)</li></ul> | Supported                     |
+| ![](http://www1.miwifi.com/statics/img/RA72.png)    | [Xiaomi AX3600](https://www.mi.com/r3600)                        | <ul><li>1.1.19(CN)</li><li>3.0.22(Global)</li></ul>  | Supported                     |
+| ![](http://www1.miwifi.com/statics/img/AX1800.png)  | [Xiaomi AX1800](https://www.mi.com/buy/detail?product_id=12027)  | <ul><li>1.0.378(CN)</li></ul>                        | Supported                     |
+| ![](http://miwifi.com/statics/img/RA67.png)         | [Redmi AX5](https://www.mi.com/buy/detail?product_id=12258)      | <ul><li>1.0.33(CN)</li><li>3.0.34(Global)</li></ul>  | Supported                     |
+| ![](http://www1.miwifi.com/statics/img/2100@1x.png) | [Xiaomi AC2100](https://www.mi.com/miwifiac)                     | <ul><li>2.0.23(CN)</li><li>2.0.743(CN)</li></ul>     | Supported                     |
+| ![](http://www1.miwifi.com/statics/img/R4AC.png)    | [Xiaomi Mi Wifi 4A](https://www.mi.com/miwifi4a/)                | <ul><li>2.28.58(CN)</li></ul>                        | Supported                     |
+| ![](http://www1.miwifi.com/statics/img/r3p.png)     | [Xiaomi PRO R3P](http://item.mi.com/1172800043.html)             | <ul><li>2.16.29(CN)</li></ul>                        | With restrictions<sup>*</sup> |
 
 <sup>*</sup> Not all integration options may be supported.

--- a/custom_components/miwifi/binary_sensor.py
+++ b/custom_components/miwifi/binary_sensor.py
@@ -7,6 +7,7 @@ from typing import Optional
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT, BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ENTITY_CATEGORY_DIAGNOSTIC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .core.util import _generate_entity_id
@@ -34,6 +35,7 @@ class MiWiFiBinarySensor(BinarySensorEntity):
         self._code = code
         self._data = data
         self._state = False
+        self._attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
 
         self.entity_id = _generate_entity_id(
             ENTITY_ID_FORMAT,

--- a/custom_components/miwifi/light.py
+++ b/custom_components/miwifi/light.py
@@ -5,6 +5,7 @@ import homeassistant.helpers.device_registry as dr
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.components.light import ENTITY_ID_FORMAT, LightEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ENTITY_CATEGORY_CONFIG
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .core.util import _generate_entity_id
@@ -32,6 +33,7 @@ class MiWiFiLight(LightEntity):
         self._data = data
         self._state = False
         self._is_block = False
+        self._attr_entity_category = ENTITY_CATEGORY_CONFIG
 
         self.entity_id = _generate_entity_id(
             ENTITY_ID_FORMAT,

--- a/custom_components/miwifi/switch.py
+++ b/custom_components/miwifi/switch.py
@@ -5,6 +5,7 @@ import homeassistant.helpers.device_registry as dr
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ENTITY_CATEGORY_DIAGNOSTIC
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .core.util import _generate_entity_id
@@ -32,6 +33,7 @@ class MiWiFiSwitch(SwitchEntity):
         self._data = data
         self._state = False
         self._is_block = False
+        self._attr_entity_category = ENTITY_CATEGORY_DIAGNOSTIC
 
         self.entity_id = _generate_entity_id(
             ENTITY_ID_FORMAT,


### PR DESCRIPTION
**Proposed change**
Add entity_category CONFIG & DIAGNOSTIC to miwifi. 
https://developers.home-assistant.io/blog/2021/10/26/config-entity/

Entities which have the entity_category set:

- Are not included in a service call targetting a whole device or area.
- Are, by default, not exposed to Google Assistant or Alexa.
- Are shown on a separate card on the device configuration page.
- Do not show up on the automatically generated Lovelace Dashboards.

The code change is tested and works locally. I have also tried adding support for Device configuration URL​ but the button never showed up.

And by the way, I am running your addon with my AX3600 and version 1.1.19(CN), therefore I have edited the readme.