### PR TITLE
Update some deprecated code

### DIFF
--- a/custom_components/miwifi/device_tracker.py
+++ b/custom_components/miwifi/device_tracker.py
@@ -9,7 +9,7 @@ from contextlib import closing
 from functools import cached_property
 from typing import Any, Final
 
-from homeassistant.components.device_tracker import ENTITY_ID_FORMAT, SOURCE_TYPE_ROUTER
+from homeassistant.components.device_tracker import ENTITY_ID_FORMAT, SourceType
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -351,7 +351,7 @@ class MiWifiDeviceTracker(ScannerEntity, CoordinatorEntity):
         :return str: Source type router
         """
 
-        return SOURCE_TYPE_ROUTER
+        return SourceType.ROUTER
 
     @cached_property
     def entity_registry_enabled_default(self) -> bool:

--- a/custom_components/miwifi/enum.py
+++ b/custom_components/miwifi/enum.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from enum import Enum, IntEnum  # type: ignore
-
-from homeassistant.backports.enum import StrEnum
+from enum import Enum, IntEnum, StrEnum  # type: ignore
 
 from .const import (
     ATTR_SWITCH_WIFI_2_4,

--- a/custom_components/miwifi/light.py
+++ b/custom_components/miwifi/light.py
@@ -9,6 +9,7 @@ from typing import Any, Final
 
 from homeassistant.components.light import (
     ENTITY_ID_FORMAT,
+    ColorMode,
     LightEntity,
     LightEntityDescription,
 )
@@ -88,6 +89,8 @@ class MiWifiLight(MiWifiEntity, LightEntity):
         MiWifiEntity.__init__(self, unique_id, description, updater, ENTITY_ID_FORMAT)
 
         self._attr_is_on = updater.data.get(description.key, False)
+        self._attr_color_mode = ColorMode.ONOFF
+        self._attr_supported_color_modes = {ColorMode.ONOFF}
         self._change_icon(self._attr_is_on)
 
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/miwifi/sensor.py
+++ b/custom_components/miwifi/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import DATA_MEGABYTES, PERCENTAGE, TEMP_CELSIUS
+from homeassistant.const import UnitOfInformation, UnitOfTemperature, PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -99,7 +99,7 @@ MIWIFI_SENSORS: tuple[SensorEntityDescription, ...] = (
         key=ATTR_SENSOR_MEMORY_TOTAL,
         name=ATTR_SENSOR_MEMORY_TOTAL_NAME,
         icon="mdi:memory",
-        native_unit_of_measurement=DATA_MEGABYTES,
+        native_unit_of_measurement=UnitOfInformation.MEGABYTES,
         state_class=SensorStateClass.TOTAL,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
@@ -108,7 +108,7 @@ MIWIFI_SENSORS: tuple[SensorEntityDescription, ...] = (
         key=ATTR_SENSOR_TEMPERATURE,
         name=ATTR_SENSOR_TEMPERATURE_NAME,
         icon="mdi:temperature-celsius",
-        native_unit_of_measurement=TEMP_CELSIUS,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,

--- a/custom_components/miwifi/services.py
+++ b/custom_components/miwifi/services.py
@@ -9,9 +9,8 @@ from typing import Final
 import homeassistant.components.persistent_notification as pn
 import voluptuous as vol
 from homeassistant.const import CONF_DEVICE_ID, CONF_IP_ADDRESS, CONF_TYPE
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.typing import ServiceCallType
 
 from .const import (
     ATTR_DEVICE_HW_VERSION,
@@ -54,10 +53,10 @@ class MiWifiServiceCall:
 
         self.hass = hass
 
-    def get_updater(self, service: ServiceCallType) -> LuciUpdater:
+    def get_updater(self, service: ServiceCall) -> LuciUpdater:
         """Get updater.
 
-        :param service: ServiceCallType
+        :param service: ServiceCall
         :return LuciUpdater
         """
 
@@ -76,10 +75,10 @@ class MiWifiServiceCall:
             f"Device {device_id} does not support the called service. Choose a router with MiWifi support."  # pylint: disable=line-too-long
         )
 
-    async def async_call_service(self, service: ServiceCallType) -> None:
+    async def async_call_service(self, service: ServiceCall) -> None:
         """Execute service call.
 
-        :param service: ServiceCallType
+        :param service: ServiceCall
         """
 
         raise NotImplementedError  # pragma: no cover
@@ -91,10 +90,10 @@ class MiWifiCalcPasswdServiceCall(MiWifiServiceCall):
     salt_old: str = "A2E371B0-B34B-48A5-8C40-A7133F3B5D88"
     salt_new: str = "6d2df50a-250f-4a30-a5e6-d44fb0960aa0"
 
-    async def async_call_service(self, service: ServiceCallType) -> None:
+    async def async_call_service(self, service: ServiceCall) -> None:
         """Execute service call.
 
-        :param service: ServiceCallType
+        :param service: ServiceCall
         """
 
         _updater: LuciUpdater = self.get_updater(service)
@@ -122,10 +121,10 @@ class MiWifiRequestServiceCall(MiWifiServiceCall):
         {vol.Required(CONF_URI): str, vol.Optional(CONF_BODY): dict}
     )
 
-    async def async_call_service(self, service: ServiceCallType) -> None:
+    async def async_call_service(self, service: ServiceCall) -> None:
         """Execute service call.
 
-        :param service: ServiceCallType
+        :param service: ServiceCall
         """
 
         updater: LuciUpdater = self.get_updater(service)


### PR DESCRIPTION
There are several slight refactorings to get rid of errors and warnings, caused by deprecated HA code usage, including:

- `DATA_MEGABYTES`, `TEMP_CELSIUS` constants are removed from the `homeassistant.const` in favor of UnitOfInformation and UnitOfTemperature subclasses with corresponding fields;
- `SOURCE_TYPE_ROUTER` is no longer available in the `homeassistant.components.device_tracker`. There is a new `SourceType.ROUTER` field;
- `homeassistant.helpers.typing.ServiceCallType` is deprecated and will be removed soon. Use the `homeassistant.core.ServiceCall` instead;
- `homeassistant.backports.enum.StrEnum` is no longer needed and will be removed soon. `enum.StrEnum` is now available;
- Fix the light component, which must report supported color modes now.

Should fix the #359

## Summary by Sourcery

Update deprecated Home Assistant constants and types.

Bug Fixes:
- Fix the light component to report supported color modes.

Enhancements:
- Replace deprecated `homeassistant.const` constants with `UnitOfInformation` and `UnitOfTemperature` subclasses.
- Replace `homeassistant.components.device_tracker.SOURCE_TYPE_ROUTER` with `SourceType.ROUTER`.
- Replace `homeassistant.helpers.typing.ServiceCallType` with `homeassistant.core.ServiceCall`.
- Remove `homeassistant.backports.enum.StrEnum` since `enum.StrEnum` is now available.